### PR TITLE
Specify minimum Emacs version

### DIFF
--- a/blueprint-ts-mode.el
+++ b/blueprint-ts-mode.el
@@ -4,6 +4,7 @@
 
 ;; Author: Huan Thieu Nguyen <nguyenthieuhuan@gmail.com>
 ;; Version: 0.0.1
+;; Package-Requires: ((emacs "29.1"))
 ;; URL: https://github.com/huanie/blueprint-ts-mode
 ;; Keywords: languages, blueprint, tree-sitter, gnome, gtk
 


### PR DESCRIPTION
tree-sitter is available since Emacs 29.1