### PR TITLE
Autoload adding of .blp to auto-mode-alist

### DIFF
--- a/blueprint-ts-mode.el
+++ b/blueprint-ts-mode.el
@@ -136,7 +136,9 @@ Saves me from writing :language `LANGUAGE' for every `RULES'."
     (setq-local treesit-font-lock-settings blueprint-ts-mode--tresit-font-lock-setting)
     (treesit-major-mode-setup)))
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.blp\\'" . blueprint-ts-mode))
+
 (add-to-list 'eglot-server-programs
 	     '(blueprint-ts-mode . ("blueprint-compiler" "lsp")))
 


### PR DESCRIPTION
This allows `.blp` files to be loaded with this mode without any additional configuration.