### PR TITLE
Actually use spaces for indentation

### DIFF
--- a/blueprint-ts-mode.el
+++ b/blueprint-ts-mode.el
@@ -129,6 +129,8 @@ Saves me from writing :language `LANGUAGE' for every `RULES'."
 		(append "{}():;,[]" electric-indent-chars))
     ;; Indent
     (setq-local treesit-simple-indent-rules blueprint-ts-mode--indent-rules)
+    (setq-local indent-tabs-mode nil)
+    (setq-local tab-width blueprint-ts-mode-indent-offset)
     ;; Navigation
     (setq-local treesit-defun-type-regexp
 		(rx (or "template" "object" "menu")))


### PR DESCRIPTION
I'm not a 100% sure if this is correct, but from what I've seen, something like this is needed to make eg. `eglot-format` actually use the correct indentation.